### PR TITLE
Migrate from set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -53,7 +53,7 @@ jobs:
           START=$(date --iso-8601=ns)
           sleep 10
           END=$(date --iso-8601=ns)
-          echo "::set-output name=result::$START $END"
+          echo "result=$START $END" >>"$GITHUB_OUTPUT"
 
   job2:
     runs-on: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
           START=$(date --iso-8601=ns)
           sleep 10
           END=$(date --iso-8601=ns)
-          echo "::set-output name=result::$START $END"
+          echo "result=$START $END" >>"$GITHUB_OUTPUT"
 
   job3:
     runs-on: ubuntu-latest
@@ -91,7 +91,7 @@ jobs:
           START=$(date --iso-8601=ns)
           sleep 10
           END=$(date --iso-8601=ns)
-          echo "::set-output name=result::$START $END"
+          echo "result=$START $END" >>"$GITHUB_OUTPUT"
 
   validation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because set-output is deprecated:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

In this project, only the integration test workflow is affected.