### PR TITLE
Remove deprecation warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,6 @@ import * as lock from './lock'
 
 async function run() {
   try {
-    core.warning(
-      'shogo82148/actions-mutex is no longer maintained. ' +
-        'Please consider use official support for limiting concurrency. ' +
-        'https://github.com/shogo82148/actions-mutex#official-concurrency-support-on-github-actions'
-    )
-
     const required = {
       required: true
     }


### PR DESCRIPTION
The upstream remains archived and is still no longer maintained, but this fork is now maintained.

This only affects the messages shown when the action runs. The material from the upstream readme, including the note about the (upstream) project no longer being maintained, is still kept, for reference.