### PR TITLE
Use "--omit=dev" instead of "--production"

### DIFF
--- a/release
+++ b/release
@@ -32,7 +32,7 @@ npm ci
 npm run build
 
 # Remove development packages from node_modules.
-npm prune --production
+npm prune --omit=dev
 perl -ne 'print unless m(^/node_modules/|/lib/$)' -i .gitignore
 
 # Publish to GitHub.


### PR DESCRIPTION
As the option to `npm prune`. This fixes the warning:

```text
npm WARN config production Use `--omit=dev` instead.
```